### PR TITLE
Readability improvements

### DIFF
--- a/Source/Models/Pupil.cs
+++ b/Source/Models/Pupil.cs
@@ -8,6 +8,6 @@
 
         public string Grade { get; set; }
 
-        public bool Promoted { get; set; }
+        public bool IsPromoted { get; set; }
     }
 }

--- a/Source/Services/FileService.cs
+++ b/Source/Services/FileService.cs
@@ -33,8 +33,8 @@ namespace Grade.Promoter.Services
 
             using (var writer = File.CreateText(path))
             {
-                var promotedPupils = pupils.Where(x => x.Promoted);
-                var promotedNotPupils = pupils.Where(x => !x.Promoted);
+                var promotedPupils = pupils.Where(x => x.IsPromoted);
+                var promotedNotPupils = pupils.Where(x => !x.IsPromoted);
 
                 writer.WriteLine("Promoted:");
 

--- a/Source/Services/PromotionService.cs
+++ b/Source/Services/PromotionService.cs
@@ -23,7 +23,7 @@ namespace Grade.Promoter.Services
                 PupilName = examResults.First().PupilName,
                 Grade = examResults.First().Grade,
                 PupilId = examResults.First().PupilId,
-                Promoted = examResults.Average(x => x.Result) > 50,
+                IsPromoted = examResults.Average(x => x.Result) > 50,
             };
         }
     }

--- a/Tests/GradePromoter.Test/UnitTest/GradePromoterTest.cs
+++ b/Tests/GradePromoter.Test/UnitTest/GradePromoterTest.cs
@@ -46,7 +46,7 @@
                     PupilId = 0,
                     PupilName = pupilName,
                     Grade = grade,
-                    Promoted = false,
+                    IsPromoted = false,
                 },
             };
 

--- a/Tests/GradePromoter.Test/UnitTest/PromotionServiceTests.cs
+++ b/Tests/GradePromoter.Test/UnitTest/PromotionServiceTests.cs
@@ -44,10 +44,10 @@ namespace Grade.Promoter.Test.UnitTest
                 },
             };
 
-            var results = this.promotionService.GetPromotionResults(examResults);
-            results.Count.ShouldBe(1);
-            var result = results.Single();
-            result.Promoted.ShouldBeTrue();
+            var pupils = this.promotionService.GetPromotionResults(examResults);
+            pupils.Count.ShouldBe(1);
+            var pupil = pupils.Single();
+            pupil.IsPromoted.ShouldBeTrue();
         }
 
         [Fact]
@@ -77,10 +77,10 @@ namespace Grade.Promoter.Test.UnitTest
                 },
             };
 
-            var results = this.promotionService.GetPromotionResults(examResults);
-            results.Count.ShouldBe(1);
-            var result = results.Single();
-            result.Promoted.ShouldBeFalse();
+            var pupils = this.promotionService.GetPromotionResults(examResults);
+            pupils.Count.ShouldBe(1);
+            var pupil = pupils.Single();
+            pupil.IsPromoted.ShouldBeFalse();
         }
     }
 }


### PR DESCRIPTION
PR:
- renames "results" in tests to "pupils" for clarity
- renames Promoted -> IsPromoted

If people dislike the Promoted -> IsPromoted rename, I can undo that and just keep the results -> pupils rename.